### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A TypeScript implementation of a Model Context Protocol (MCP) server that integrates with Google's Gemini Pro model.
 
+<a href="https://glama.ai/mcp/servers/ejwvacw7s0">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ejwvacw7s0/badge" alt="Gemini Server MCP server" />
+</a>
+
 ## MCP Tools
 
 ### generate_text


### PR DESCRIPTION
This PR adds a badge for the [Gemini MCP Server](https://glama.ai/mcp/servers/ejwvacw7s0) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ejwvacw7s0">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ejwvacw7s0/badge" alt="Gemini Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.